### PR TITLE
configure private NAT gateway for onpremises

### DIFF
--- a/tf/core/bastion.tf
+++ b/tf/core/bastion.tf
@@ -66,6 +66,9 @@ resource "aws_instance" "bastion" {
   tags = {
     Name = "bastion"
   }
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "aws_eip_association" "bastion" {


### PR DESCRIPTION
use static NAT on onpremises router devices so they don't need to handle 
dynamic NAPT table and allow redundancy