### PR TITLE
NocAdmin: Grant access to s3://rubykaigi-public

### DIFF
--- a/tf/admin-iam/noc_admin.tf
+++ b/tf/admin-iam/noc_admin.tf
@@ -133,8 +133,8 @@ data "aws_iam_policy_document" "NocAdminBase" {
       "arn:aws:s3:::rk-takeout-app/*",
       "arn:aws:s3:::am-i-not-at-rubykaigi",
       "arn:aws:s3:::am-i-not-at-rubykaigi/*",
-      "arn:aws:s3:::rk-cloudprober",
-      "arn:aws:s3:::rk-cloudprober/*",
+      "arn:aws:s3:::rubykaigi-public",
+      "arn:aws:s3:::rubykaigi-public/*",
     ]
   }
 


### PR DESCRIPTION
instead of too specifically named bucket. @sorah 

https://github.com/ruby-no-kai/rubykaigi-nw/pull/77#issuecomment-1534360412