### PR TITLE
k8s: Allow place fluent-bit daemon to CriticalAddonsOnly nodes

### DIFF
--- a/gen/k8s/syslog/daemonset.yml
+++ b/gen/k8s/syslog/daemonset.yml
@@ -83,6 +83,12 @@
                   "key": "dedicated",
                   "operator": "Equal",
                   "value": "onpremises"
+               },
+               {
+                  "effect": "NoSchedule",
+                  "key": "CriticalAddonsOnly",
+                  "operator": "Equal",
+                  "value": "true"
                }
             ],
             "volumes": [

--- a/k8s/syslog/daemonset.jsonnet
+++ b/k8s/syslog/daemonset.jsonnet
@@ -71,6 +71,12 @@
             value: 'onpremises',
             effect: 'NoSchedule',
           },
+          {
+            key: 'CriticalAddonsOnly',
+            operator: 'Equal',
+            value: 'true',
+            effect: 'NoSchedule',
+          },
         ],
       },
     },


### PR DESCRIPTION
これで全nodesに置かれます(置かれています)